### PR TITLE
Implement Pillow-based image analizer&processor

### DIFF
--- a/sphinx/api.rst
+++ b/sphinx/api.rst
@@ -206,6 +206,12 @@ WandAnalyzer
 .. autoclass:: WandAnalyzer
 
 
+PILAnalyzer
+^^^^^^^^^^^
+
+.. autoclass:: PILAnalyzer
+
+
 Validator
 ^^^^^^^^^
 
@@ -227,6 +233,12 @@ ImageProcessor
 ^^^^^^^^^^^^^^
 
 .. autoclass:: ImageProcessor
+
+
+PILImageProcessor
+^^^^^^^^^^^^^^^^^
+
+.. autoclass:: PILImageProcessor
 
 
 exceptions Module

--- a/sqlalchemy_media/optionals.py
+++ b/sqlalchemy_media/optionals.py
@@ -59,6 +59,26 @@ def ensure_wand():
         raise OptionalPackageRequirementError('wand')
 
 
+# PIL / Pillow
+
+try:
+    # noinspection PyPackageRequirements
+    import PIL
+except ImportError:  # pragma: no cover
+    PIL = None
+
+
+def ensure_pil():
+    """
+
+    .. warning:: :exc:`.OptionalPackageRequirementError` will be raised if ``Pillow`` is not installed.
+
+    """
+
+    if PIL is None:  # pragma: no cover
+        raise OptionalPackageRequirementError('Pillow')
+
+
 # requests-aws4auth
 try:
     # noinspection PyPackageRequirements

--- a/sqlalchemy_media/tests/test_analyzers.py
+++ b/sqlalchemy_media/tests/test_analyzers.py
@@ -3,7 +3,7 @@ import unittest
 import io
 from os.path import dirname, abspath, join
 
-from sqlalchemy_media.processors import MagicAnalyzer, WandAnalyzer
+from sqlalchemy_media.processors import MagicAnalyzer, WandAnalyzer, PILAnalyzer
 from sqlalchemy_media.descriptors import AttachableDescriptor
 
 
@@ -38,6 +38,17 @@ class AnalyzerTestCase(unittest.TestCase):
 
     def test_wand(self):
         analyzer = WandAnalyzer()
+        with AttachableDescriptor(self.cat_jpeg) as d:
+            ctx = {}
+            analyzer.process(d, ctx)
+            self.assertDictEqual(ctx, {
+                'width': 640,
+                'height': 480,
+                'content_type': 'image/jpeg'
+            })
+
+    def test_pil(self):
+        analyzer = PILAnalyzer()
         with AttachableDescriptor(self.cat_jpeg) as d:
             ctx = {}
             analyzer.process(d, ctx)


### PR DESCRIPTION
This is a first step into solving issue #84.

I wanted to try SA-Media for an application I'm writing that runs within a Docker container: using Wand would require installing its development libraries and the whole C toolchain. OTOH, Pillow come with binary wheels...

My main incertitudes are:

- I used the method [Image.thumbnail()](http://pillow.readthedocs.io/en/latest/reference/Image.html?highlight=thumbnail#PIL.Image.Image.thumbnail) to scale the image, for simplicity: should it use [Image.resize()](http://pillow.readthedocs.io/en/latest/reference/Image.html?highlight=thumbnail#PIL.Image.Image.resize) instead?
- The [Image.crop()](http://pillow.readthedocs.io/en/latest/reference/Image.html?highlight=thumbnail#PIL.Image.Image.crop) method is much simpler than the `Wand` one: maybe we could provide an approximation? (see this [gist](https://gist.github.com/sigilioso/2957026) for a first cut)
