### PR TITLE
Fix import typos in image tutorial

### DIFF
--- a/sphinx/tutorials/image.rst
+++ b/sphinx/tutorials/image.rst
@@ -89,11 +89,11 @@ the ``as_mutable`` method is used to make a type mutable.
 
     from sqlalchemy import Column, Integer
 
-    from sqlalchemy_media import Image, ImageAnalizer, ImageValidator, ImageProcessor
+    from sqlalchemy_media import Image, ImageAnalyzer, ImageValidator, ImageProcessor
 
     class ProfileImage(Image):
         __pre_processors__ = [
-            ImageAnalizer(),
+            ImageAnalyzer(),
             ImageValidator(
                 minimum=(80, 80),
                 maximum=(800, 600),

--- a/sqlalchemy_media/imaginglibs.py
+++ b/sqlalchemy_media/imaginglibs.py
@@ -11,6 +11,6 @@ def get_image_factory():
     except OptionalPackageRequirementError:
         # Re-raising the exception again, because currently there is only one image library
         # available, but after implementing the #97 the exception should be passed silently.
-        # And should raised if the neghter PILLOW and or PIL is not installed.
+        # And should raised if the neighter PILLOW and or PIL is not installed.
         raise
 


### PR DESCRIPTION
Fixed a typo in the image tutorial documentation: `ImageAnalizer` to `ImageAnalyzer`.