### PR TITLE
Add dependency to python-magic-bin for windows and mac

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,8 @@ with open(os.path.join(
 dependencies = [
     'sqlalchemy >= 1.1.0b3',
     'pillow',
-    'python-magic >= 0.4.12'
+    'python-magic >= 0.4.12',
+    'python-magic-bin >= 0.4.12; (sys_platform=="win32" or sys_platform=="darwin")'
 ]
 
 


### PR DESCRIPTION
Support Windows (and Mac, not tested) using environment markers (https://www.python.org/dev/peps/pep-0508/#environment-markers) to conditionally install `python-magic-bin` fork (https://github.com/julian-r/python-magic) of `python-magic` to include binaries for Windows (and Mac, not tested).