### PR TITLE
Fixing a bug with image analyzer

### DIFF
--- a/sqlalchemy_media/descriptors.py
+++ b/sqlalchemy_media/descriptors.py
@@ -6,7 +6,7 @@ from urllib.request import urlopen
 
 from .constants import KB
 from .exceptions import MaximumLengthIsReachedError, \
-    DescriptorOperationError
+    DescriptorOperationError, AnalyzeError
 from .helpers import is_uri, copy_stream
 from .mimetypes_ import guess_extension, guess_type
 from .typing_ import FileLike, Attachable
@@ -449,6 +449,9 @@ class LocalFileSystemDescriptor(StreamCloserDescriptor):
             original_filename=original_filename,
             **kwargs
         )
+
+    def readline(self):
+        return self._file.readline()
 
 
 class UrlDescriptor(StreamCloserDescriptor):

--- a/sqlalchemy_media/descriptors.py
+++ b/sqlalchemy_media/descriptors.py
@@ -451,6 +451,9 @@ class LocalFileSystemDescriptor(StreamCloserDescriptor):
         )
 
     def readline(self):
+        """
+        Just to be compatible with underlying file-like object.
+        """
         return self._file.readline()
 
 

--- a/sqlalchemy_media/processors.py
+++ b/sqlalchemy_media/processors.py
@@ -359,7 +359,7 @@ class ImageAnalyzer(Analyzer):
         try:
             img = PilImage.open(descriptor)
         except OSError:
-            raise AnalyzeError('Cannot identify image file')
+            raise AnalyzeError('Cannot identify the requested image file')
 
         context.update(
             width=img.width,

--- a/sqlalchemy_media/processors.py
+++ b/sqlalchemy_media/processors.py
@@ -6,7 +6,7 @@ from PIL import Image as PilImage
 from .descriptors import StreamDescriptor
 from .exceptions import ContentTypeValidationError, DimensionValidationError, \
     AspectRatioValidationError, AnalyzeError
-from .helpers import validate_width_height_ratio, deprecated
+from .helpers import validate_width_height_ratio
 from .mimetypes_ import guess_extension, guess_type, magic_mime_from_buffer
 from .typing_ import Dimension
 
@@ -356,7 +356,11 @@ class ImageAnalyzer(Analyzer):
         # This processor requires seekable stream.
         descriptor.prepare_to_read(backend='memory')
 
-        img = PilImage.open(descriptor)
+        try:
+            img = PilImage.open(descriptor)
+        except OSError:
+            raise AnalyzeError('Cannot identify image file')
+
         context.update(
             width=img.width,
             height=img.height,

--- a/sqlalchemy_media/tests/test_image_analyzer.py
+++ b/sqlalchemy_media/tests/test_image_analyzer.py
@@ -2,6 +2,7 @@ import unittest
 from os.path import dirname, abspath, join
 
 from sqlalchemy_media.descriptors import AttachableDescriptor
+from sqlalchemy_media.exceptions import AnalyzeError
 from sqlalchemy_media.processors import ImageAnalyzer
 
 
@@ -13,6 +14,8 @@ class ImageAnalyzerTestCase(unittest.TestCase):
         cls.stuff_path = join(cls.this_dir, 'stuff')
         cls.cat_jpeg = join(cls.stuff_path, 'cat.jpg')
         cls.cat_png = join(cls.stuff_path, 'cat.png')
+        cls.cat_txt = join(cls.stuff_path, 'sample_text_file1.txt')
+
 
     def test_image_analyzer(self):
         analyzer = ImageAnalyzer()
@@ -24,6 +27,11 @@ class ImageAnalyzerTestCase(unittest.TestCase):
                 'height': 480,
                 'content_type': 'image/jpeg'
             })
+
+        with AttachableDescriptor(self.cat_txt) as d:
+            ctx = {}
+            with self.assertRaises(AnalyzeError):
+                analyzer.process(d, ctx)
 
 
 if __name__ == '__main__':  # pragma: no cover


### PR DESCRIPTION
While using image analyzer, attaching a file with wrong content type cause an irreverent error.