### PR TITLE
improve Flask and Werkzeug integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,10 +76,8 @@ docs/doctest
 docs/doctrees
 docs/html
 htmlcov
-/examples/cherrypy-demo/avatars
-/examples/cherrypy-demo/demo.db
-/examples/flask/demo.db
-/examples/flask/static/avatars/
+/examples/**/demo.db
+/examples/**/static/avatars/
 
 .ropeproject
 

--- a/examples/flask-form/app.py
+++ b/examples/flask-form/app.py
@@ -1,0 +1,120 @@
+import json
+import functools
+from os import path, mkdir, getcwd
+
+from flask import Flask, g, redirect, render_template, url_for
+from flask_wtf import CSRFProtect, FlaskForm
+from flask_wtf.file import FileField, FileSize, FileAllowed, FileRequired
+from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy import TypeDecorator, Unicode
+from sqlalchemy_media import (
+    Image, ImageValidator, ImageProcessor, ImageAnalyzer,
+    StoreManager, FileSystemStore,
+)
+from sqlalchemy_media.constants import MB, KB
+from wtforms import fields
+
+
+ROOT_PATH = path.abspath(getcwd())
+TEMP_PATH = path.join(ROOT_PATH, 'static', 'avatars')
+
+app = Flask(__name__)
+app.config['SECRET_KEY'] = 'super-sekret-key'
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///demo.db'
+app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+db = SQLAlchemy(app)
+csrf = CSRFProtect(app)
+
+
+StoreManager.register(
+    'fs',
+    functools.partial(FileSystemStore, TEMP_PATH, '/static/avatars'),
+    default=True
+)
+
+
+class Json(TypeDecorator):
+    impl = Unicode
+
+    def process_bind_param(self, value, engine):
+        return json.dumps(value)
+
+    def process_result_value(self, value, engine):
+        if value is None:
+            return None
+        return json.loads(value)
+
+
+class Avatar(Image):
+    __auto_coercion__ = True
+    __pre_processors__ = [
+        ImageAnalyzer(),
+        ImageValidator(
+            minimum=(10, 10),
+            maximum=(4000, 4000),
+            content_types=('image/jpeg', 'image/png', 'image/gif'),
+            min_aspect_ratio=1,
+            max_aspect_ratio=2,
+        ),
+        ImageProcessor(fmt='jpeg', width=128)
+    ]
+    __max_length__ = 6 * MB
+    __min_length__ = 10 * KB
+
+
+class Person(db.Model):
+    __tablename__ = 'person'
+
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(Unicode)
+    avatar = db.Column(Avatar.as_mutable(Json))
+
+
+class PersonForm(FlaskForm):
+    name = fields.StringField(render_kw=dict(placeholder='Avatar Name (optional)'))
+    avatar = FileField(validators=[
+        FileAllowed(['jpg', 'jpeg', 'png', 'gif']),
+        FileSize(min_size=10*KB, max_size=6*MB),
+        FileRequired(),
+    ])
+    submit = fields.SubmitField('Submit')
+
+
+@app.before_first_request
+def setup_dev_env():
+    if not path.exists(TEMP_PATH):
+        mkdir(TEMP_PATH)
+    db.create_all()
+
+
+@app.before_request
+def push_store_manager():
+    g.store_manager = StoreManager.push_new(db.session, delete_orphan=True)
+
+
+@app.after_request
+def pop_store_manager(response):
+    g.store_manager.pop()
+    g.store_manager = None
+    return response
+
+
+@app.route("/", methods=['GET', 'POST'])
+def index():
+    form = PersonForm()
+    if form.validate_on_submit():
+        avatar = form.avatar.data
+        person = Person(avatar=avatar,
+                        name=form.name.data or avatar.filename)
+        db.session.add(person)
+        db.session.commit()
+        return redirect(url_for('index'))
+
+    people = db.session.query(Person).all()
+    return render_template('index.html', form=form, people=people)
+
+
+@app.errorhandler(500)
+def internal_error(exception):
+    app.logger.error(exception)
+    return "500"

--- a/examples/flask-form/requirements.txt
+++ b/examples/flask-form/requirements.txt
@@ -1,0 +1,4 @@
+flask
+flask-wtf
+flask-sqlalchemy
+sqlalchemy-media

--- a/examples/flask-form/templates/index.html
+++ b/examples/flask-form/templates/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Flask SQLAlchemy-Media Demo</title>
+  </head>
+
+  <body>
+    <h1>Flask SQLAlchemy-Media Demo</h1>
+
+    <h2>Avatars</h2>
+    {% if not people %}
+      <p>No avatars have been added yet, add one below!</p>
+    {% else %}
+      <ul>
+        {% for person in people %}
+          <li>
+            <h3>{{ person.name }}</h3>
+            <img src="{{ person.avatar.locate() }}" alt="{{ person.name }}">
+          </li>
+        {% endfor %}
+      </ul>
+    {% endif %}
+
+    <hr />
+    <h2>Add Avatar</h2>
+    <form method="POST" action="/" enctype="multipart/form-data">
+      {{ form.hidden_tag() }}
+      <p>{{ form.avatar() }}</p>
+      <p>{{ form.name() }}</p>
+      <p>{{ form.submit() }}</p>
+    </form>
+  </body>
+</html>


### PR DESCRIPTION
This PR improves the out-of-the-box experience with Flask and Werkzeug by:

* improving `StreamDescriptor` to automatically detect `original_filename`, `content_type`, and `content_length` from Werkzueg POST requests
* allows for the `StoreManager` context to be tied to the request-response cycle without forcing users to always remember to wrap their code with a context manager
* adds another Flask demo app demonstrating said capabilities with Flask-WTF