### PR TITLE
add ExifTransposeProcessor and ThumbnailProcessor

### DIFF
--- a/sqlalchemy_media/thumbnails.py
+++ b/sqlalchemy_media/thumbnails.py
@@ -1,0 +1,59 @@
+import io
+from PIL import Image as PilImage
+from typing import Tuple, Type, Union
+
+from .attachments import Thumbnail
+from .descriptors import StreamDescriptor
+from .helpers import validate_width_height_ratio
+from .typing_ import FileLike
+
+
+def generate_thumbnail(
+    original_image: Union[FileLike, StreamDescriptor],
+    width: int = None,
+    height: int = None,
+    ratio: float = None,
+    ratio_precision: int = 5,
+    thumbnail_type: Type[Thumbnail] = Thumbnail,
+) -> Tuple[int, int, float, Thumbnail]:
+    width, height, ratio = validate_width_height_ratio(
+        width, height, ratio
+    )
+    thumbnail_buffer = io.BytesIO()
+    format_ = 'jpeg'
+    extension = '.jpg'
+
+    # generating thumbnail and storing in buffer
+    img = PilImage.open(original_image)
+
+    # JPEG does not handle Alpha channel, switch to PNG
+    if img.mode == 'RGBA':
+        format_ = 'png'
+        extension = '.png'
+
+    with img:
+        original_size = img.size
+
+        if callable(width):
+            width = width(original_size)
+        if callable(height):
+            height = height(original_size)
+
+        width = int(width)
+        height = int(height)
+
+        thumbnail_image = img.resize((width, height))
+        thumbnail_image.save(thumbnail_buffer, format_)
+
+    thumbnail_buffer.seek(0)
+
+    ratio = round(width / original_size[0], ratio_precision)
+    thumbnail = thumbnail_type.create_from(
+        thumbnail_buffer,
+        content_type=f'image/{format_}',
+        extension=extension,
+        dimension=(width, height)
+    )
+
+    return width, height, ratio, thumbnail
+


### PR DESCRIPTION
This PR adds two new image processors.

`ThumbnailProcessor` is used to create thumbnails from the source image. Using a processor over a function call on `Image` has at least two advantages, namely, that thumbnail generation can happen automatically when image data is attached to a model, and because processing happens while the original image data is still in memory, does not require hitting the network to fetch the original image when generating new thumbnails.

`ExifTransposeProcessor` is used to call [`PIL.ImageOps.exif_transpose`](https://pillow.readthedocs.io/en/stable/reference/ImageOps.html#PIL.ImageOps.exif_transpose) on an image before saving it to the store. This is primarily useful to fix the orientation of generated thumbnails when the source image has an EXIF orientation tag _not_ equal to 1.
