### PR TITLE
Only require python-magic on linux

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(os.path.join(
 dependencies = [
     'sqlalchemy >= 1.1.0b3',
     'pillow',
-    'python-magic >= 0.4.12',
+    'python-magic >= 0.4.12; (sys_platform=="linux")',
     'python-magic-bin >= 0.4.12; (sys_platform=="win32" or sys_platform=="darwin")'
 ]
 


### PR DESCRIPTION
On Windows, currently the installation of `sqlalchemy-media` also installs `python-magic`. `python-magic` brakes the usage of `magic` since at least in our setups `libmagic` cant be found. When uninstalling `python-magic` (so only `python-magic-bin` is installed)`, everything works as expected. 

I modified the `setup.py` to only require `python-magic` on `linux` platforms. This fixes the installation issue on Windows. 